### PR TITLE
fix: correct npm metadata urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
   "homepage": "https://github.com/SaltyAom/mobius",
   "repository": {
     "type": "git",
-    "url": "://github.com/SaltyAom/mobius"
+    "url": "git+https://github.com/SaltyAom/mobius.git"
   },
-  "bugs": "://github.com/SaltyAom/mobius/issues",
+  "bugs": {
+    "url": "https://github.com/SaltyAom/mobius/issues"
+  },
   "license": "MIT",
   "scripts": {
     "dev": "bun run --watch example/index.ts",


### PR DESCRIPTION
## Summary
- fix the malformed repository URL in `package.json`
- expose npm `bugs.url` with the GitHub issues URL

## Validation
- `node -e "const p=require('./package.json'); if(p.repository.url!=='git+https://github.com/SaltyAom/mobius.git') throw new Error('bad repo'); if(p.bugs.url!=='https://github.com/SaltyAom/mobius/issues') throw new Error('bad bugs');"`
- `npm pack --dry-run --json --ignore-scripts`